### PR TITLE
fix: set numpy and scikit-learn versions to avoid dependency issues

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,3 +21,5 @@ dependencies:
     - matplotlib>=3.7.2
     - seaborn>=0.12.2
     - pandas>=2.0.3
+    - scikit-learn==1.3.2
+    - numpy==1.26.4


### PR DESCRIPTION
### PR: Dependency Update for scikit-learn and numpy to Resolve Compatibility Issues

This PR updates `scikit-learn` and `numpy` versions to address compatibility issues encountered during recent development work, specifically with `hpobench` and `pandas` dependencies.

#### Dependency Updates:
1. **scikit-learn**: Updated to `1.3.2`
   - **Error**: The `OneHotEncoder` in `scikit-learn` version 1.4 and above now requires the parameter `sparse_output` instead of `sparse`, causing `hpobench`'s use of `OneHotEncoder(sparse=False)` to throw a `TypeError`.
   - **Solution**: Downgraded `scikit-learn` to version `1.3.2` where `sparse` is still recognized as a valid parameter.
   - **Reference**: [Related issue and solution](https://github.com/shankarpandala/lazypredict/issues/442#issuecomment-1926476335)

2. **numpy**: Updated to `1.26.4`
   - **Error**: `pandas 2.0.3` installs the latest `numpy` version, which leads to a binary incompatibility error on Python 3.9:
     ```
     ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject.
     ```
   - **Solution**: Updated `numpy` to version `1.26.4` to maintain compatibility with Python 3.9.
   - **Reference**: [Related StackOverflow discussion](https://stackoverflow.com/questions/78634235/numpy-dtype-size-changed-may-indicate-binary-incompatibility-expected-96-from)

---
Hi! I had some issues running your project at first, after digging a little bit I found the solution.

These changes resolved the compatibility issues for me without affecting other functionality.

Great project! Best regards, Matheus.